### PR TITLE
fix: unnecessary parentheses around `if` condition

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -145,7 +145,7 @@ impl Args {
         if let Some(llm_api_base_url) = self.llm_api_base_url {
             config.llm.api_base_url = llm_api_base_url;
         } else {
-            if (config.llm.provider == LLMProvider::Ollama) {
+            if config.llm.provider == LLMProvider::Ollama {
                 config.llm.api_base_url = "http://localhost:11434".to_owned();
             }
         }


### PR DESCRIPTION
fix: unnecessary parentheses around `if` condition