### PR TITLE
Harden LLM deserialization and fallback handling

### DIFF
--- a/src/generator/compose/agents/architecture_editor.rs
+++ b/src/generator/compose/agents/architecture_editor.rs
@@ -32,13 +32,27 @@ impl StepForwardAgent for ArchitectureEditor {
                 DataSource::ResearchResult(ResearchAgentType::WorkflowResearcher.to_string()),
             ],
             // Use architecture, deployment, database and ADR docs
-            optional_sources: vec![DataSource::knowledge_categories(vec!["architecture", "deployment", "database", "adr"])],
+            optional_sources: vec![DataSource::knowledge_categories(vec![
+                "architecture",
+                "deployment",
+                "database",
+                "adr",
+            ])],
         }
     }
 
     fn prompt_template(&self) -> PromptTemplate {
         PromptTemplate {
             system_prompt: r#"You are a professional software architecture documentation expert, focused on generating complete, in-depth, and detailed C4 architecture model documentation. Your task is to write an architecture documentation titled `Architecture Overview` based on the provided research reports.
+
+## Mermaid Diagram Safety Rules (MUST follow):
+- Always output Mermaid that compiles in strict Mermaid parsers.
+- Use ASCII-only node IDs: `[A-Za-z0-9_]` (example: `WebDemo`, `InferenceService`, `FabricAPI`).
+- Keep business/localized text in labels only, e.g. `WebDemo["Web Demo hội thoại"]`.
+- Define all nodes first, then declare edges between existing IDs.
+- Use only supported headers (`graph TD`, `graph LR`, `flowchart TD`, `sequenceDiagram`, `erDiagram`).
+- Do not include hidden characters, smart quotes, or non-standard symbols in Mermaid source.
+- Keep edge labels short plain text; avoid markdown and overly complex punctuation.
 
 ## Your Professional Capabilities:
 1. **Architecture Analysis Capability**: Deep understanding of system architecture patterns, design principles, and technology selection

--- a/src/generator/compose/agents/overview_editor.rs
+++ b/src/generator/compose/agents/overview_editor.rs
@@ -43,6 +43,15 @@ impl StepForwardAgent for OverviewEditor {
 
 Your task is to write a complete, in-depth, detailed, and easy-to-read C4 SystemContext document titled `Project Overview` based on the provided system context research report and domain module analysis results.
 
+## Mermaid Diagram Safety Rules (MUST follow):
+- Always generate Mermaid that is syntactically valid in strict parsers.
+- Use ASCII-only node IDs: `[A-Za-z0-9_]` (e.g. `ClientApp`, `BackendAPI`).
+- Put localized/human-readable text only inside node labels, e.g. `ClientApp["Ứng dụng khách hàng"]`.
+- Define every node ID before using it in edges.
+- Use only standard diagram headers like `graph TD`, `graph LR`, `flowchart TD`, `sequenceDiagram`, `erDiagram`.
+- Do not use hidden/zero-width characters, smart quotes, or unusual Unicode symbols in Mermaid code.
+- Keep edge labels simple plain text without markdown formatting.
+
 ## External Knowledge Integration:
 You may have access to existing product description, requirements and architecture documentation from external sources.
 If available:

--- a/src/generator/compose/agents/workflow_editor.rs
+++ b/src/generator/compose/agents/workflow_editor.rs
@@ -32,7 +32,10 @@ impl StepForwardAgent for WorkflowEditor {
                 DataSource::CODE_INSIGHTS,
             ],
             // Use workflow docs for workflow documentation
-            optional_sources: vec![DataSource::knowledge_categories(vec!["workflow", "architecture"])],
+            optional_sources: vec![DataSource::knowledge_categories(vec![
+                "workflow",
+                "architecture",
+            ])],
         }
     }
 
@@ -41,6 +44,15 @@ impl StepForwardAgent for WorkflowEditor {
             system_prompt: r#"You are a professional software architecture documentation expert, focused on analyzing and writing system core workflow documentation.
 
 Your task is to write a complete, in-depth, and detailed workflow document titled `Core Workflows` based on the provided multi-dimensional research analysis results.
+
+## Mermaid Diagram Safety Rules (MUST follow):
+- Always produce Mermaid syntax that is valid for strict Mermaid parsers.
+- Use ASCII-only node IDs: `[A-Za-z0-9_]` (e.g. `StartNode`, `ValidateInput`, `CallBackend`).
+- Put localized text in labels only, e.g. `StartNode["Người dùng bắt đầu quy trình"]`.
+- Declare all node IDs before referencing them in edges.
+- Use standard diagram headers only (`flowchart TD`, `graph TD`, `graph LR`, `sequenceDiagram`).
+- Avoid hidden characters, smart quotes, markdown formatting, and unusual Unicode symbols inside Mermaid source.
+- Keep edge labels concise plain text.
 
 ## Your Professional Capabilities:
 1. **Workflow Analysis Skills**: Deep understanding of system core workflows, business processes, and technical processes

--- a/src/generator/preprocess/agents/code_analyze.rs
+++ b/src/generator/preprocess/agents/code_analyze.rs
@@ -42,15 +42,24 @@ impl CodeAnalyze {
 
                 Box::pin(async move {
                     let code_analyze = CodeAnalyze { language_processor };
-                    let agent_params = code_analyze
+                    let (agent_params, mut static_insight) = code_analyze
                         .prepare_single_code_agent_params(&project_structure_clone, &code_clone)
                         .await?;
-                    let mut code_insight =
-                        extract::<CodeInsight>(&context_clone, agent_params).await?;
+                    static_insight.code_dossier.source_summary = code_clone.source_summary.to_owned();
 
-                    // LLM will rewrite source_summary, so exclude it and override here
+                    let mut code_insight = match extract::<CodeInsight>(&context_clone, agent_params).await {
+                        Ok(insight) => insight,
+                        Err(e) => {
+                            eprintln!(
+                                "⚠️ AI code insight failed for {}: {}. Falling back to static analysis.",
+                                code_clone.name, e
+                            );
+                            return Result::<CodeInsight>::Ok(static_insight);
+                        }
+                    };
+
+                    // LLM may rewrite source_summary, so exclude it and override here
                     code_insight.code_dossier.source_summary = code_clone.source_summary.to_owned();
-
                     Result::<CodeInsight>::Ok(code_insight)
                 })
             })
@@ -73,7 +82,10 @@ impl CodeAnalyze {
             }
         }
 
-        println!("✓ Concurrent code analysis completed, successfully analyzed {} files", code_insights.len());
+        println!(
+            "✓ Concurrent code analysis completed, successfully analyzed {} files",
+            code_insights.len()
+        );
         Ok(code_insights)
     }
 }
@@ -83,7 +95,7 @@ impl CodeAnalyze {
         &self,
         project_structure: &ProjectStructure,
         codes: &CodeDossier,
-    ) -> Result<AgentExecuteParams> {
+    ) -> Result<(AgentExecuteParams, CodeInsight)> {
         // First perform static analysis
         let code_analyse = self.analyze_code_by_rules(codes, project_structure).await?;
 
@@ -91,12 +103,15 @@ impl CodeAnalyze {
         let prompt_user = self.build_code_analysis_prompt(project_structure, &code_analyse);
         let prompt_sys = include_str!("prompts/code_analyze_sys.tpl").to_string();
 
-        Ok(AgentExecuteParams {
-            prompt_sys,
-            prompt_user,
-            cache_scope: "ai_code_insight".to_string(),
-            log_tag: codes.name.to_string(),
-        })
+        Ok((
+            AgentExecuteParams {
+                prompt_sys,
+                prompt_user,
+                cache_scope: "ai_code_insight".to_string(),
+                log_tag: codes.name.to_string(),
+            },
+            code_analyse,
+        ))
     }
 }
 

--- a/src/generator/preprocess/agents/code_purpose_analyze.rs
+++ b/src/generator/preprocess/agents/code_purpose_analyze.rs
@@ -1,21 +1,75 @@
 use anyhow::Result;
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::path::Path;
 
-use crate::{
-    types::code::{CodePurpose, CodePurposeMapper},
-};
 use crate::generator::agent_executor::{AgentExecuteParams, extract};
 use crate::generator::context::GeneratorContext;
+use crate::types::code::{CodePurpose, CodePurposeMapper};
+
+fn deserialize_code_purpose_from_any<'de, D>(deserializer: D) -> Result<CodePurpose, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    let raw = match value {
+        serde_json::Value::Null => String::new(),
+        serde_json::Value::String(s) => s,
+        serde_json::Value::Bool(v) => v.to_string(),
+        serde_json::Value::Number(v) => v.to_string(),
+        serde_json::Value::Array(v) => serde_json::to_string(&v).unwrap_or_default(),
+        serde_json::Value::Object(v) => serde_json::to_string(&v).unwrap_or_default(),
+    };
+    Ok(CodePurposeMapper::map_from_raw(&raw))
+}
+
+fn deserialize_f64_lenient<'de, D>(deserializer: D) -> Result<f64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    let result = match value {
+        serde_json::Value::Number(n) => n.as_f64().unwrap_or(0.0),
+        serde_json::Value::String(s) => s.parse::<f64>().unwrap_or(0.0),
+        serde_json::Value::Bool(v) => {
+            if v {
+                1.0
+            } else {
+                0.0
+            }
+        }
+        _ => 0.0,
+    };
+    Ok(result)
+}
+
+fn deserialize_string_lenient<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    let result = match value {
+        serde_json::Value::Null => String::new(),
+        serde_json::Value::String(s) => s,
+        serde_json::Value::Bool(v) => v.to_string(),
+        serde_json::Value::Number(v) => v.to_string(),
+        serde_json::Value::Array(v) => serde_json::to_string(&v).unwrap_or_default(),
+        serde_json::Value::Object(v) => serde_json::to_string(&v).unwrap_or_default(),
+    };
+    Ok(result)
+}
 
 /// AI component type analysis result
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default, JsonSchema)]
+#[serde(default)]
 pub struct AICodePurposeAnalysis {
     // Inferred code functionality classification
+    #[serde(default, deserialize_with = "deserialize_code_purpose_from_any")]
     pub code_purpose: CodePurpose,
     // Confidence of the inference result (min 0.0, max 1.0), confidence is high when > 0.7.
+    #[serde(default, deserialize_with = "deserialize_f64_lenient")]
     pub confidence: f64,
+    #[serde(default, deserialize_with = "deserialize_string_lenient")]
     pub reasoning: String,
 }
 
@@ -32,8 +86,8 @@ impl CodePurposeEnhancer {
         context: &GeneratorContext,
         file_path: &Path,
         file_name: &str,
-        file_content: &str) -> Result<CodePurpose>
-    {
+        file_content: &str,
+    ) -> Result<CodePurpose> {
         // First use rule mapping
         let rule_based_type =
             CodePurposeMapper::map_by_path_and_name(&file_path.to_string_lossy(), file_name);
@@ -45,14 +99,19 @@ impl CodePurposeEnhancer {
 
         // If there's AI analyzer and file content, use AI enhanced analysis
         let prompt_sys = "You are a professional code architecture analyst specializing in analyzing component types of code files.".to_string();
-        let prompt_user = self.build_code_purpose_analysis_prompt(file_path, file_content, file_name);
+        let prompt_user =
+            self.build_code_purpose_analysis_prompt(file_path, file_content, file_name);
 
-        let analyze_result = extract::<AICodePurposeAnalysis>(context, AgentExecuteParams {
-            prompt_sys,
-            prompt_user,
-            cache_scope: "ai_code_purpose".to_string(),
-            log_tag: file_name.to_string(),
-        }).await;
+        let analyze_result = extract::<AICodePurposeAnalysis>(
+            context,
+            AgentExecuteParams {
+                prompt_sys,
+                prompt_user,
+                cache_scope: "ai_code_purpose".to_string(),
+                log_tag: file_name.to_string(),
+            },
+        )
+        .await;
 
         return match analyze_result {
             Ok(ai_analysis) => {
@@ -71,7 +130,7 @@ impl CodePurposeEnhancer {
                 // AI analysis failed, use rule result
                 Ok(rule_based_type)
             }
-        }
+        };
     }
 
     /// Build component type analysis prompt
@@ -95,5 +154,40 @@ impl CodePurposeEnhancer {
             file_name,
             content_preview
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AICodePurposeAnalysis;
+    use crate::types::code::CodePurpose;
+
+    #[test]
+    fn test_ai_code_purpose_analysis_deserialize_unknown_variant_text() {
+        let payload = serde_json::json!({
+            "code_purpose": "Migration configuration script (Alembic env file)",
+            "confidence": "0.91",
+            "reasoning": {"summary":"matched migration config"}
+        });
+
+        let parsed: AICodePurposeAnalysis = serde_json::from_value(payload)
+            .expect("AICodePurposeAnalysis should deserialize loose purpose variant");
+
+        assert_eq!(parsed.code_purpose, CodePurpose::Config);
+        assert_eq!(parsed.confidence, 0.91);
+    }
+
+    #[test]
+    fn test_ai_code_purpose_analysis_deserialize_short_service_api_text() {
+        let payload = serde_json::json!({
+            "code_purpose": "Service API for external calls",
+            "confidence": 0.8,
+            "reasoning": "api classification"
+        });
+
+        let parsed: AICodePurposeAnalysis = serde_json::from_value(payload)
+            .expect("AICodePurposeAnalysis should deserialize shortened API variant");
+
+        assert_eq!(parsed.code_purpose, CodePurpose::Api);
     }
 }

--- a/src/generator/research/types.rs
+++ b/src/generator/research/types.rs
@@ -182,7 +182,8 @@ pub struct BusinessFlow {
 }
 
 /// Core component analysis result
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, JsonSchema)]
+#[serde(default)]
 pub struct KeyModuleReport {
     /// Domain name
     pub domain_name: String,
@@ -498,3 +499,22 @@ impl Default for DatabaseOverviewReport {
 
 // https://c4model.com/abstractions/software-system
 // System name, project's role and value, system type, who is using it, how to use, which external systems it interacts with, diagram
+
+#[cfg(test)]
+mod tests {
+    use super::KeyModuleReport;
+
+    #[test]
+    fn test_key_module_report_deserialize_with_missing_module_name() {
+        let payload = serde_json::json!({
+            "domain_name": "Tài liệu & IaC",
+            "module_description": "Infrastructure and documentation module"
+        });
+
+        let report: KeyModuleReport = serde_json::from_value(payload)
+            .expect("KeyModuleReport should deserialize when module_name is missing");
+
+        assert_eq!(report.module_name, "");
+        assert_eq!(report.domain_name, "Tài liệu & IaC");
+    }
+}

--- a/src/types/code.rs
+++ b/src/types/code.rs
@@ -4,72 +4,256 @@ use std::{
 };
 
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
+
+fn json_value_to_string(value: serde_json::Value) -> String {
+    match value {
+        serde_json::Value::Null => String::new(),
+        serde_json::Value::String(s) => s,
+        serde_json::Value::Bool(v) => v.to_string(),
+        serde_json::Value::Number(v) => v.to_string(),
+        serde_json::Value::Array(v) => serde_json::to_string(&v).unwrap_or_default(),
+        serde_json::Value::Object(v) => {
+            for key in [
+                "name",
+                "module",
+                "path",
+                "summary",
+                "description",
+                "title",
+                "value",
+                "text",
+                "id",
+            ] {
+                if let Some(inner) = v.get(key) {
+                    let text = json_value_to_string(inner.clone());
+                    if !text.is_empty() {
+                        return text;
+                    }
+                }
+            }
+            serde_json::to_string(&v).unwrap_or_default()
+        }
+    }
+}
+
+fn deserialize_string_lenient<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    Ok(json_value_to_string(value))
+}
+
+fn deserialize_option_string_lenient<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    match value {
+        serde_json::Value::Null => Ok(None),
+        other => Ok(Some(json_value_to_string(other))),
+    }
+}
+
+fn deserialize_vec_string_lenient<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    let values = match value {
+        serde_json::Value::Null => Vec::new(),
+        serde_json::Value::Array(items) => items
+            .into_iter()
+            .map(json_value_to_string)
+            .filter(|v| !v.is_empty())
+            .collect(),
+        other => {
+            let one = json_value_to_string(other);
+            if one.is_empty() {
+                Vec::new()
+            } else {
+                vec![one]
+            }
+        }
+    };
+
+    Ok(values)
+}
+
+fn deserialize_interfaces_lenient<'de, D>(deserializer: D) -> Result<Vec<InterfaceInfo>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    let mut interfaces = Vec::new();
+
+    let items = match value {
+        serde_json::Value::Null => Vec::new(),
+        serde_json::Value::Array(items) => items,
+        other => vec![other],
+    };
+
+    for item in items {
+        match item {
+            serde_json::Value::String(name) => interfaces.push(InterfaceInfo {
+                name,
+                ..Default::default()
+            }),
+            serde_json::Value::Object(_) => {
+                if let Ok(interface) = serde_json::from_value::<InterfaceInfo>(item.clone()) {
+                    interfaces.push(interface);
+                } else {
+                    interfaces.push(InterfaceInfo {
+                        name: json_value_to_string(item),
+                        ..Default::default()
+                    });
+                }
+            }
+            other => interfaces.push(InterfaceInfo {
+                name: json_value_to_string(other),
+                ..Default::default()
+            }),
+        }
+    }
+
+    Ok(interfaces)
+}
+
+fn deserialize_dependencies_lenient<'de, D>(deserializer: D) -> Result<Vec<Dependency>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    let mut dependencies = Vec::new();
+
+    let items = match value {
+        serde_json::Value::Null => Vec::new(),
+        serde_json::Value::Array(items) => items,
+        other => vec![other],
+    };
+
+    for item in items {
+        match item {
+            serde_json::Value::String(name) => dependencies.push(Dependency {
+                name,
+                ..Default::default()
+            }),
+            serde_json::Value::Object(_) => {
+                if let Ok(dependency) = serde_json::from_value::<Dependency>(item.clone()) {
+                    dependencies.push(dependency);
+                } else {
+                    dependencies.push(Dependency {
+                        name: json_value_to_string(item),
+                        ..Default::default()
+                    });
+                }
+            }
+            other => dependencies.push(Dependency {
+                name: json_value_to_string(other),
+                ..Default::default()
+            }),
+        }
+    }
+
+    Ok(dependencies)
+}
+
+fn deserialize_code_purpose_lenient<'de, D>(deserializer: D) -> Result<CodePurpose, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    let raw = json_value_to_string(value);
+    Ok(CodePurposeMapper::map_from_raw(&raw))
+}
 
 /// Code basic information
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default, JsonSchema)]
+#[serde(default)]
 pub struct CodeDossier {
     /// Code file name
+    #[serde(default, deserialize_with = "deserialize_string_lenient")]
     pub name: String,
     /// File path
     pub file_path: PathBuf,
     /// Source code summary
     #[schemars(skip)]
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_string_lenient")]
     pub source_summary: String,
     /// Purpose type
+    #[serde(default, deserialize_with = "deserialize_code_purpose_lenient")]
     pub code_purpose: CodePurpose,
     /// Importance score
     pub importance_score: f64,
     pub description: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_vec_string_lenient")]
     pub functions: Vec<String>,
     /// Interfaces list
+    #[serde(default, deserialize_with = "deserialize_vec_string_lenient")]
     pub interfaces: Vec<String>,
 }
 
 /// Intelligent insight information of code file
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default, JsonSchema)]
+#[serde(default)]
 pub struct CodeInsight {
     /// Code basic information
     pub code_dossier: CodeDossier,
+    #[serde(default, deserialize_with = "deserialize_string_lenient")]
     pub detailed_description: String,
     /// Responsibilities
+    #[serde(default, deserialize_with = "deserialize_vec_string_lenient")]
     pub responsibilities: Vec<String>,
     /// Contained interfaces
+    #[serde(default, deserialize_with = "deserialize_interfaces_lenient")]
     pub interfaces: Vec<InterfaceInfo>,
     /// Dependency information
+    #[serde(default, deserialize_with = "deserialize_dependencies_lenient")]
     pub dependencies: Vec<Dependency>,
     pub complexity_metrics: CodeComplexity,
 }
 
 /// Interface information
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default, JsonSchema)]
+#[serde(default)]
 pub struct InterfaceInfo {
+    #[serde(default, deserialize_with = "deserialize_string_lenient")]
     pub name: String,
+    #[serde(default, deserialize_with = "deserialize_string_lenient")]
     pub interface_type: String, // "function", "method", "class", "trait", etc.
-    pub visibility: String,     // "public", "private", "protected"
+    #[serde(default, deserialize_with = "deserialize_string_lenient")]
+    pub visibility: String, // "public", "private", "protected"
     pub parameters: Vec<ParameterInfo>,
     pub return_type: Option<String>,
     pub description: Option<String>,
 }
 
 /// Parameter information
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default, JsonSchema)]
+#[serde(default)]
 pub struct ParameterInfo {
+    #[serde(default, deserialize_with = "deserialize_string_lenient")]
     pub name: String,
+    #[serde(default, deserialize_with = "deserialize_string_lenient")]
     pub param_type: String,
     pub is_optional: bool,
     pub description: Option<String>,
 }
 
 /// Dependency information
-#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, JsonSchema)]
+#[serde(default)]
 pub struct Dependency {
+    #[serde(default, deserialize_with = "deserialize_string_lenient")]
     pub name: String,
+    #[serde(default, deserialize_with = "deserialize_option_string_lenient")]
     pub path: Option<String>,
     pub is_external: bool,
     pub line_number: Option<usize>,
+    #[serde(default, deserialize_with = "deserialize_string_lenient")]
     pub dependency_type: String, // "import", "use", "include", "require", etc.
+    #[serde(default, deserialize_with = "deserialize_option_string_lenient")]
     pub version: Option<String>,
 }
 
@@ -90,7 +274,8 @@ impl Display for Dependency {
 }
 
 /// Component complexity metrics
-#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default, JsonSchema)]
+#[serde(default)]
 pub struct CodeComplexity {
     pub cyclomatic_complexity: f64,
     pub lines_of_code: usize,
@@ -115,7 +300,14 @@ pub enum CodePurpose {
     #[serde(alias = "Frontend UI component")]
     Widget,
     /// Code module for implementing specific logical functionality
-    #[serde(alias = "feature", alias = "specific_feature", alias = "specific-feature", alias = "Code module for implementing specific logical functionality")]
+    #[serde(
+        alias = "feature",
+        alias = "specific_feature",
+        alias = "specific-feature",
+        alias = "Specificfeature",
+        alias = "SpecificFeature",
+        alias = "Code module for implementing specific logical functionality"
+    )]
     SpecificFeature,
     /// Data type or model
     #[serde(alias = "Data type or model")]
@@ -127,7 +319,9 @@ pub enum CodePurpose {
     #[serde(alias = "Functional tool code for specific scenarios")]
     Tool,
     /// Common, basic utility functions and classes, providing low-level auxiliary functions unrelated to business logic
-    #[serde(alias = "Common, basic utility functions and classes, providing low-level auxiliary functions unrelated to business logic")]
+    #[serde(
+        alias = "Common, basic utility functions and classes, providing low-level auxiliary functions unrelated to business logic"
+    )]
     Util,
     /// Configuration
     #[serde(alias = "configuration", alias = "Configuration")]
@@ -145,16 +339,24 @@ pub enum CodePurpose {
     #[serde(alias = "Database component")]
     Database,
     /// Service API for external calls, providing calling capabilities based on HTTP, RPC, IPC and other protocols.
-    #[serde(alias = "Service API for external calls, providing calling capabilities based on HTTP, RPC, IPC and other protocols.")]
+    #[serde(
+        alias = "Service API for external calls, providing calling capabilities based on HTTP, RPC, IPC and other protocols."
+    )]
     Api,
     /// Controller component in MVC architecture, responsible for handling business logic
-    #[serde(alias = "Controller component in MVC architecture, responsible for handling business logic")]
+    #[serde(
+        alias = "Controller component in MVC architecture, responsible for handling business logic"
+    )]
     Controller,
     /// Service component in MVC architecture, responsible for handling business rules
-    #[serde(alias = "Service component in MVC architecture, responsible for handling business rules")]
+    #[serde(
+        alias = "Service component in MVC architecture, responsible for handling business rules"
+    )]
     Service,
     /// Collection of related code (functions, classes, resources) with clear boundaries and responsibilities
-    #[serde(alias = "Collection of related code (functions, classes, resources) with clear boundaries and responsibilities")]
+    #[serde(
+        alias = "Collection of related code (functions, classes, resources) with clear boundaries and responsibilities"
+    )]
     Module,
     /// Dependency library
     #[serde(alias = "library", alias = "package", alias = "Dependency library")]
@@ -163,7 +365,11 @@ pub enum CodePurpose {
     #[serde(alias = "testing", alias = "tests", alias = "Test component")]
     Test,
     /// Documentation component
-    #[serde(alias = "documentation", alias = "docs", alias = "Documentation component")]
+    #[serde(
+        alias = "documentation",
+        alias = "docs",
+        alias = "Documentation component"
+    )]
     Doc,
     /// Data Access Layer component
     #[serde(alias = "Data Access Layer component")]
@@ -172,10 +378,18 @@ pub enum CodePurpose {
     #[serde(alias = "Context component")]
     Context,
     /// command-line interface (CLI) commands or message/request handlers
-    #[serde(alias = "command-line interface (CLI) commands or message/request handlers", alias = "command-line interface (CLI) commands or message/request handlers")]
+    #[serde(
+        alias = "command-line interface (CLI) commands or message/request handlers",
+        alias = "command-line interface (CLI) commands or message/request handlers"
+    )]
     Command,
     /// Other uncategorized or unknown
-    #[serde(alias = "unknown", alias = "misc", alias = "miscellaneous", alias = "Other uncategorized or unknown")]
+    #[serde(
+        alias = "unknown",
+        alias = "misc",
+        alias = "miscellaneous",
+        alias = "Other uncategorized or unknown"
+    )]
     Other,
 }
 
@@ -228,6 +442,89 @@ impl Default for CodePurpose {
 pub struct CodePurposeMapper;
 
 impl CodePurposeMapper {
+    pub fn map_from_raw(raw: &str) -> CodePurpose {
+        let normalized = raw
+            .to_lowercase()
+            .chars()
+            .filter(char::is_ascii_alphanumeric)
+            .collect::<String>();
+
+        if normalized.is_empty() {
+            return CodePurpose::Other;
+        }
+        if normalized.contains("specificfeature") || normalized == "feature" {
+            return CodePurpose::SpecificFeature;
+        }
+        if normalized.contains("frontenduicomponent") || normalized == "widget" {
+            return CodePurpose::Widget;
+        }
+        if normalized.contains("frontenduipage") || normalized == "page" {
+            return CodePurpose::Page;
+        }
+        if normalized.contains("agent") {
+            return CodePurpose::Agent;
+        }
+        if normalized.contains("entry") {
+            return CodePurpose::Entry;
+        }
+        if normalized.contains("database") {
+            return CodePurpose::Database;
+        }
+        if normalized.contains("config") {
+            return CodePurpose::Config;
+        }
+        if normalized.contains("context") {
+            return CodePurpose::Context;
+        }
+        if normalized.contains("router") {
+            return CodePurpose::Router;
+        }
+        if normalized.contains("serviceapi") {
+            return CodePurpose::Api;
+        }
+        if normalized.contains("service") {
+            return CodePurpose::Service;
+        }
+        if normalized.contains("controller") {
+            return CodePurpose::Controller;
+        }
+        if normalized.contains("api") {
+            return CodePurpose::Api;
+        }
+        if normalized.contains("model") {
+            return CodePurpose::Model;
+        }
+        if normalized.contains("types") {
+            return CodePurpose::Types;
+        }
+        if normalized.contains("util") || normalized.contains("helper") {
+            return CodePurpose::Util;
+        }
+        if normalized.contains("tool") {
+            return CodePurpose::Tool;
+        }
+        if normalized.contains("module") {
+            return CodePurpose::Module;
+        }
+        if normalized.contains("dao") || normalized.contains("repository") {
+            return CodePurpose::Dao;
+        }
+        if normalized.contains("test") {
+            return CodePurpose::Test;
+        }
+        if normalized.contains("doc") {
+            return CodePurpose::Doc;
+        }
+        if normalized.contains("command") || normalized.contains("cli") {
+            return CodePurpose::Command;
+        }
+        if normalized.contains("library") || normalized.contains("package") || normalized == "lib" {
+            return CodePurpose::Lib;
+        }
+
+        CodePurpose::Other
+    }
+
     /// Intelligent mapping based on file path and name
     pub fn map_by_path_and_name(file_path: &str, file_name: &str) -> CodePurpose {
         let path_lower = file_path.to_lowercase();
@@ -383,28 +680,19 @@ mod tests {
     fn test_sql_file_classification() {
         // .sqlproj files should always be classified as Database
         assert_eq!(
-            CodePurposeMapper::map_by_path_and_name(
-                "/src/MyProject.sqlproj",
-                "MyProject.sqlproj"
-            ),
+            CodePurposeMapper::map_by_path_and_name("/src/MyProject.sqlproj", "MyProject.sqlproj"),
             CodePurpose::Database
         );
 
         // .sql files should always be classified as Database
         assert_eq!(
-            CodePurposeMapper::map_by_path_and_name(
-                "/src/CreateTable.sql",
-                "CreateTable.sql"
-            ),
+            CodePurposeMapper::map_by_path_and_name("/src/CreateTable.sql", "CreateTable.sql"),
             CodePurpose::Database
         );
 
         // Even in root directory
         assert_eq!(
-            CodePurposeMapper::map_by_path_and_name(
-                "/Schema.sql",
-                "Schema.sql"
-            ),
+            CodePurposeMapper::map_by_path_and_name("/Schema.sql", "Schema.sql"),
             CodePurpose::Database
         );
 
@@ -422,10 +710,7 @@ mod tests {
     fn test_sql_file_in_database_folder() {
         // SQL files in /database/ folder should still be Database
         assert_eq!(
-            CodePurposeMapper::map_by_path_and_name(
-                "/src/database/schema.sql",
-                "schema.sql"
-            ),
+            CodePurposeMapper::map_by_path_and_name("/src/database/schema.sql", "schema.sql"),
             CodePurpose::Database
         );
     }
@@ -434,10 +719,7 @@ mod tests {
     fn test_path_based_classification() {
         // Files in /database/ folder
         assert_eq!(
-            CodePurposeMapper::map_by_path_and_name(
-                "/src/database/connection.cs",
-                "connection.cs"
-            ),
+            CodePurposeMapper::map_by_path_and_name("/src/database/connection.cs", "connection.cs"),
             CodePurpose::Database
         );
 
@@ -449,5 +731,93 @@ mod tests {
             ),
             CodePurpose::Dao
         );
+    }
+
+    #[test]
+    fn test_code_insight_deserialize_with_missing_fields() {
+        let payload = serde_json::json!({
+            "code_dossier": {
+                "name": "chat-window.tsx",
+                "file_path": "src/chat-window.tsx"
+            },
+            "interfaces": [
+                {
+                    "interface_type": "function"
+                }
+            ],
+            "dependencies": [
+                {
+                    "path": "react",
+                    "is_external": true
+                }
+            ]
+        });
+
+        let insight: CodeInsight = serde_json::from_value(payload).expect(
+            "CodeInsight should support partial model outputs and fill defaults for missing fields",
+        );
+
+        assert_eq!(insight.code_dossier.name, "chat-window.tsx");
+        assert_eq!(
+            insight.code_dossier.file_path,
+            PathBuf::from("src/chat-window.tsx")
+        );
+        assert_eq!(insight.code_dossier.code_purpose, CodePurpose::Other);
+        assert!(insight.responsibilities.is_empty());
+        assert_eq!(insight.interfaces[0].name, "");
+        assert_eq!(insight.dependencies[0].name, "");
+    }
+
+    #[test]
+    fn test_code_insight_deserialize_with_specificfeature_variant() {
+        let payload = serde_json::json!({
+            "code_dossier": {
+                "name": "connect-button.tsx",
+                "file_path": "src/connect-button.tsx",
+                "code_purpose": "Specificfeature"
+            }
+        });
+
+        let insight: CodeInsight = serde_json::from_value(payload).expect(
+            "CodeInsight should accept common model variant typo `Specificfeature` for code_purpose",
+        );
+
+        assert_eq!(
+            insight.code_dossier.code_purpose,
+            CodePurpose::SpecificFeature
+        );
+    }
+
+    #[test]
+    fn test_code_insight_deserialize_with_loose_schema_values() {
+        let payload = serde_json::json!({
+            "code_dossier": {
+                "name": "use-toast.ts",
+                "file_path": "src/use-toast.ts",
+                "code_purpose": "widget"
+            },
+            "detailed_description": {
+                "summary": "hook for toast state"
+            },
+            "interfaces": [
+                "State interface"
+            ],
+            "dependencies": [
+                {
+                    "name": {"module": "react"},
+                    "is_external": true
+                }
+            ]
+        });
+
+        let insight: CodeInsight = serde_json::from_value(payload)
+            .expect("CodeInsight should tolerate loose schema values from LLM output");
+
+        assert_eq!(insight.code_dossier.name, "use-toast.ts");
+        assert_eq!(insight.detailed_description, "hook for toast state");
+        assert_eq!(insight.interfaces.len(), 1);
+        assert_eq!(insight.interfaces[0].name, "State interface");
+        assert_eq!(insight.dependencies.len(), 1);
+        assert_eq!(insight.dependencies[0].name, "react");
     }
 }


### PR DESCRIPTION
## Summary
This PR improves resilience when model outputs do not strictly match expected schemas during documentation generation.

It addresses failures like:
- `Failed to deserialize ... missing field 'name'`
- `Failed to deserialize ... missing field 'responsibilities'`
- Similar missing/loose field issues in AI analysis outputs

## Root Cause
Some LLM responses are schema-unstable (missing required fields, variant naming drift, mixed value shapes such as object/string/array), while parts of the pipeline previously required strict deserialization.

## Changes
- Hardened deserialization for code insight structures with lenient parsing and defaults.
- Added tolerant mapping for `CodePurpose` from raw/variant text.
- Added robust parsing for AI code-purpose analysis fields (`code_purpose`, `confidence`, `reasoning`).
- Added fallback behavior in code insight analysis:
  - if AI extraction fails, return static-analysis insight instead of failing the whole run.
- Added `#[serde(default)]`/`Default` handling for key report structures to avoid hard failures on partial outputs.
- Added Mermaid safety constraints to relevant compose prompts to reduce invalid Mermaid syntax generation.

## Tests
- `cargo test` passed (`53 passed, 0 failed`).
- `cargo check` passed.
- Verification repeated in a clean temporary worktree with only this patch applied.

## Scope / Out of Scope
- Scope is intentionally limited to deserialization robustness, fallback safety, and Mermaid prompt hardening.
- Large unrelated local workspace changes were intentionally excluded to keep this PR safe and reviewable.

## Impact
- Prevents pipeline interruption from non-critical LLM schema variance.
- Preserves documentation generation continuity by degrading gracefully to static analysis when needed.
- Improves output reliability without changing core workflow intent.
