### PR TITLE
fix: extract raw string from cached JSON Value instead of serializing

### DIFF
--- a/src/generator/agent_executor.rs
+++ b/src/generator/agent_executor.rs
@@ -31,7 +31,11 @@ pub async fn prompt(context: &GeneratorContext, params: AgentExecuteParams) -> R
     {
         let msg = context.config.target_language.msg_cache_hit().replace("{}", log_tag);
         println!("{}", msg);
-        return Ok(cached_reply.to_string());
+        let text = match cached_reply {
+            serde_json::Value::String(s) => s,
+            other => other.to_string(),
+        };
+        return Ok(text);
     }
 
     let (current, total) = params.progress.unwrap_or((1, 1));
@@ -83,7 +87,11 @@ pub async fn prompt_with_tools(
     {
         let msg = context.config.target_language.msg_cache_hit().replace("{}", log_tag);
         println!("{}", msg);
-        return Ok(cached_reply.to_string());
+        let text = match cached_reply {
+            serde_json::Value::String(s) => s,
+            other => other.to_string(),
+        };
+        return Ok(text);
     }
 
     let (current, total) = params.progress.unwrap_or((1, 1));


### PR DESCRIPTION
## Summary

- Fixes a bug where cached LLM responses produce malformed markdown output (JSON-escaped strings with `\n` literals instead of newlines)
- Only manifests on cache hits (second run onwards) — first run generates correctly, subsequent runs serve corrupted content from cache

## Root Cause

In `agent_executor.rs`, when a cached response is found, `cached_reply.to_string()` is called on a `serde_json::Value::String`. The `Display` impl of `Value::String` produces a JSON-serialized representation (with surrounding quotes and escaped characters), not the raw string content.

## Fix

Pattern-match on `Value::String` to extract the inner `String` directly, falling back to `.to_string()` only for non-string JSON values.

## Test plan

- [x] Run litho on a project, verify first-run output is correct markdown
- [x] Run litho again (cache hit), verify output is identical to first run
- [x] `cargo check` passes