### PR TITLE
fix: cache u64 underflow, UTF-8 slice panic, path traversal (6 bugs)

### DIFF
--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -61,7 +61,9 @@ impl CacheManager {
             .unwrap()
             .as_secs();
         let expire_seconds = self.config.expire_hours * 3600;
-        now - timestamp > expire_seconds
+        // Use saturating_sub: a timestamp in the future (clock skew, tampered
+        // cache file) must not underflow and panic.
+        now.saturating_sub(timestamp) > expire_seconds
     }
 
     /// Get cache

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -140,7 +140,13 @@ impl Args {
         let mut config = if let Some(config_path) = &self.config {
             // If config file path is explicitly specified, load from that path
             let msg = target_lang.msg_config_read_error().replace("{:?}", &format!("{:?}", config_path));
-            Config::from_file(config_path).expect(&msg)
+            match Config::from_file(config_path) {
+                Ok(c) => c,
+                Err(e) => {
+                    eprintln!("{}: {}", msg, e);
+                    std::process::exit(1);
+                }
+            }
         } else {
             // If no config file is explicitly specified, try loading from default location
             let default_config_path = std::env::current_dir()
@@ -149,7 +155,13 @@ impl Args {
 
             if default_config_path.exists() {
                 let msg = target_lang.msg_config_read_error().replace("{:?}", &format!("{:?}", default_config_path));
-                Config::from_file(&default_config_path).expect(&msg)
+                match Config::from_file(&default_config_path) {
+                    Ok(c) => c,
+                    Err(e) => {
+                        eprintln!("{}: {}", msg, e);
+                        std::process::exit(1);
+                    }
+                }
             } else {
                 // Default config file doesn't exist, use default values
                 Config::default()

--- a/src/generator/agent_executor.rs
+++ b/src/generator/agent_executor.rs
@@ -56,12 +56,14 @@ pub async fn prompt(context: &GeneratorContext, params: AgentExecuteParams) -> R
     let input_text = format!("{} {}", prompt_sys, prompt_user);
     let token_usage = estimate_token_usage(&input_text, &reply);
 
-    // Cache result - Use method with token information
+    // Cache result - Use method with token information.
+    // Note: cache the String value directly (not JSON-encoded), otherwise
+    // serde_json wraps it in quotes and cached reads return a quoted string.
     context
         .cache_manager
         .write()
         .await
-        .set_with_tokens(cache_scope, &prompt_key, &reply, token_usage)
+        .set_with_tokens(cache_scope, &prompt_key, reply.clone(), token_usage)
         .await?;
 
     Ok(reply)

--- a/src/generator/research/agents/key_modules_insight.rs
+++ b/src/generator/research/agents/key_modules_insight.rs
@@ -176,7 +176,7 @@ impl KeyModulesInsight {
         let all_insights = context
             .get_from_memory::<CodeAndDirectoryInsights>(MemoryScope::PREPROCESS, ScopedKeys::CODE_INSIGHTS)
             .await
-            .expect("memory of CODE_INSIGHTS not found in PREPROCESS");
+            .ok_or_else(|| anyhow::anyhow!("memory of CODE_INSIGHTS not found in PREPROCESS"))?;
 
         // Collect all code paths associated with this domain
         let mut domain_paths: HashSet<String> = HashSet::new();

--- a/src/generator/step_forward_agent.rs
+++ b/src/generator/step_forward_agent.rs
@@ -267,7 +267,12 @@ impl DataFormatter {
     pub fn format_readme_content(&self, readme: &str) -> String {
         let content = if let Some(limit) = self.config.readme_truncate_length {
             if readme.len() > limit {
-                format!("{}...(truncated)", &readme[..limit])
+                // Truncate at char boundary to avoid panicking on multibyte UTF-8
+                let mut end = limit;
+                while end > 0 && !readme.is_char_boundary(end) {
+                    end -= 1;
+                }
+                format!("{}...(truncated)", &readme[..end])
             } else {
                 readme.to_string()
             }

--- a/src/llm/tools/file_explorer.rs
+++ b/src/llm/tools/file_explorer.rs
@@ -43,9 +43,36 @@ impl AgentToolFileExplorer {
         Self { config }
     }
 
+    /// Resolve an agent-supplied path relative to the project root, refusing
+    /// absolute paths and `..` traversal that would escape the root.
+    fn resolve_within_root(&self, path: &str) -> Result<std::path::PathBuf> {
+        let p = std::path::Path::new(path);
+        if p.is_absolute() {
+            anyhow::bail!("absolute paths are not allowed");
+        }
+        let candidate = self.config.project_path.join(p);
+        let mut normalized = std::path::PathBuf::new();
+        for comp in candidate.components() {
+            match comp {
+                std::path::Component::ParentDir => {
+                    if !normalized.pop() {
+                        anyhow::bail!("path escapes project root");
+                    }
+                }
+                std::path::Component::CurDir => {}
+                other => normalized.push(other.as_os_str()),
+            }
+        }
+        if normalized.starts_with(&self.config.project_path) {
+            Ok(normalized)
+        } else {
+            anyhow::bail!("path escapes project root")
+        }
+    }
+
     async fn list_directory(&self, args: &FileExplorerArgs) -> Result<FileExplorerResult> {
         let target_path = if let Some(path) = &args.path {
-            self.config.project_path.join(path)
+            self.resolve_within_root(path)?
         } else {
             self.config.project_path.clone()
         };
@@ -141,7 +168,7 @@ impl AgentToolFileExplorer {
             .ok_or_else(|| anyhow::anyhow!("find_files action requires pattern parameter"))?;
 
         let search_path = if let Some(path) = &args.path {
-            self.config.project_path.join(path)
+            self.resolve_within_root(path)?
         } else {
             self.config.project_path.clone()
         };
@@ -203,7 +230,15 @@ impl AgentToolFileExplorer {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("get_file_info action requires path parameter"))?;
 
-        let target_path = self.config.project_path.join(file_path);
+        let target_path = match self.resolve_within_root(file_path) {
+            Ok(p) => p,
+            Err(_) => {
+                return Ok(FileExplorerResult {
+                    insights: vec![format!("File does not exist: {}", file_path)],
+                    ..Default::default()
+                });
+            }
+        };
 
         if !target_path.exists() {
             return Ok(FileExplorerResult {

--- a/src/llm/tools/file_reader.rs
+++ b/src/llm/tools/file_reader.rs
@@ -37,9 +37,42 @@ impl AgentToolFileReader {
         Self { config }
     }
 
+    /// Resolve an agent-supplied path relative to the project root, refusing
+    /// absolute paths and `..` traversal that would escape the root.
+    fn resolve_within_root(&self, file_path: &str) -> Option<std::path::PathBuf> {
+        let p = std::path::Path::new(file_path);
+        if p.is_absolute() {
+            return None;
+        }
+        let candidate = self.config.project_path.join(p);
+        // Walk the candidate, collapsing ".." components, and verify it stays
+        // inside the project root.
+        let mut normalized = std::path::PathBuf::new();
+        for comp in candidate.components() {
+            match comp {
+                std::path::Component::ParentDir => {
+                    if !normalized.pop() {
+                        return None;
+                    }
+                }
+                std::path::Component::CurDir => {}
+                other => normalized.push(other.as_os_str()),
+            }
+        }
+        if normalized.starts_with(&self.config.project_path) {
+            Some(normalized)
+        } else {
+            None
+        }
+    }
+
     async fn read_file_content(&self, args: &FileReaderArgs) -> Result<FileReaderResult> {
-        let project_root = &self.config.project_path;
-        let file_path = project_root.join(&args.file_path);
+        let Some(file_path) = self.resolve_within_root(&args.file_path) else {
+            return Ok(FileReaderResult {
+                file_path: args.file_path.clone(),
+                ..Default::default()
+            });
+        };
 
         if !file_path.exists() {
             return Ok(FileReaderResult {
@@ -77,7 +110,7 @@ impl AgentToolFileReader {
                 let selected_lines = &lines[..max_lines.min(lines.len())];
                 (selected_lines.join("\n"), selected_lines.len())
             } else {
-                // If file is too large, limit read lines
+                // Check if file is too large, limit read lines
                 let max_default_lines = 200;
                 if lines.len() > max_default_lines {
                     let selected_lines = &lines[..max_default_lines];


### PR DESCRIPTION
## HIGH
- **BUG-1**: cache expiry `u64` underflow → panic on future timestamps (`saturating_sub`).
- **BUG-2**: README truncation slices UTF-8 mid-codepoint → panic (char-boundary cut + suffix).
- **SEC-1**: path traversal via LLM agent file tools — absolute paths and `..` escapes now rejected.

## MEDIUM/LOW
- cli.rs config-load `expect()` → graceful error.
- agent_executor cache double-quoting.
- key_modules_insight `expect()` → error.

Verified: cargo check 0 warnings, cargo test 60/60, 11/11 behavioral checks.